### PR TITLE
Genspark ai developer

### DIFF
--- a/sections/wtf-cart.liquid
+++ b/sections/wtf-cart.liquid
@@ -78,7 +78,7 @@
                 {% if item.properties != empty %}
                   <div class="wtf-line__properties">
                     {% for p in item.properties %}
-                      {% unless p.last == blank %}
+                      {% unless p.first contains '_' or p.last == blank or p.last == 'false' %}
                         <div class="wtf-property"><strong>{{ p.first }}:</strong> {{ p.last }}</div>
                       {% endunless %}
                     {% endfor %}

--- a/sections/wtf-order-builder.liquid
+++ b/sections/wtf-order-builder.liquid
@@ -311,6 +311,10 @@
             <span>Size Upgrade</span>
             <span data-size-price>+$0.00</span>
           </div>
+          <div class="price-line" data-pumps-upcharge style="display: none;">
+            <span>Extra pumps</span>
+            <span data-pumps-price>+$0.00</span>
+          </div>
           <div class="price-line" data-boosters-upcharge style="display: none;">
             <span>Boosters</span>
             <span data-boosters-price>+$0.00</span>
@@ -851,6 +855,23 @@
       }
     };
 
+    // Pricing & pump configuration from section settings
+    const priceConfig = {
+      extraPumpPrice: parseFloat('{{ section.settings.extra_pump_price | default: 0.5 }}') || 0.5,
+      includedPumps: {
+        small: parseInt('{{ section.settings.included_pumps_small | default: 4 }}', 10) || 4,
+        medium: parseInt('{{ section.settings.included_pumps_medium | default: 4 }}', 10) || 4,
+        large: parseInt('{{ section.settings.included_pumps_large | default: 6 }}', 10) || 6,
+        gallon: parseInt('{{ section.settings.included_pumps_gallon | default: 24 }}', 10) || 24
+      },
+      sizeUpcharge: {
+        small: parseFloat('{{ section.settings.upcharge_small | default: 0 }}') || 0,
+        medium: parseFloat('{{ section.settings.upcharge_medium | default: 1 }}') || 1,
+        large: parseFloat('{{ section.settings.upcharge_large | default: 2 }}') || 2,
+        gallon: parseFloat('{{ section.settings.upcharge_gallon | default: 35 }}') || 35
+      }
+    };
+
     const orderBuilder = {
       currentCategory: 'kava',
       selectedOptions: {
@@ -868,6 +889,7 @@
       
       init() {
         this.bindEvents();
+        this.updateSizeChipLabels();
         this.updateDisplay();
         this.validateForm();
       },
@@ -1058,9 +1080,16 @@
         const counter = document.querySelector('[data-flavor-counter]');
         if (counter) {
           const text = counter.querySelector('.flavor-counter__text');
+          const limit = counter.querySelector('.flavor-counter__limit');
+          const size = this.selectedOptions.size;
+          const included = priceConfig.includedPumps[size] || 0;
+          const count = this.selectedOptions.flavors.length;
+          const extra = Math.max(0, count - included);
           if (text) {
-            const count = this.selectedOptions.flavors.length;
-            text.textContent = `${count} flavor${count !== 1 ? 's' : ''} selected`;
+            text.textContent = `${count} pump${count !== 1 ? 's' : ''} selected (${included} included, ${extra} extra)`;
+          }
+          if (limit) {
+            limit.textContent = `Extra pumps $${(priceConfig.extraPumpPrice || 0).toFixed(2)} each`;
           }
         }
       },
@@ -1091,16 +1120,13 @@
         document.dispatchEvent(new CustomEvent('wtf:size-changed', {
           detail: { size, sizeData: { price: this.getSizePriceDelta(size) } }
         }));
+
+        // Update line item properties impacted by size (included pumps, size upcharge)
+        this.updateLineItemProperties();
       },
       
       getSizePriceDelta(size) {
-        const deltas = {
-          small: 0,
-          medium: 1,
-          large: 2,
-          gallon: 35
-        };
-        return deltas[size] || 0;
+        return Number(priceConfig.sizeUpcharge[size] || 0);
       },
       
       filterFlavors(searchTerm) {
@@ -1127,8 +1153,14 @@
         const boosterTotal = this.selectedOptions.boosters.reduce((sum, b) => sum + (b.price || 0), 0);
         const concentrationDelta = this.selectedOptions.concentration === 'strong' ? 10 : 
                                    this.selectedOptions.concentration === 'extra' ? 20 : 0;
+
+        // Pump math: treat each selected flavor as one pump for now
+        const included = priceConfig.includedPumps[this.selectedOptions.size] || 0;
+        const pumpCount = this.selectedOptions.flavors.length;
+        const extraPumps = Math.max(0, pumpCount - included);
+        const pumpExtraCost = extraPumps * (priceConfig.extraPumpPrice || 0);
         
-        const subtotal = this.basePrice + sizeDelta + boosterTotal + concentrationDelta;
+        const subtotal = this.basePrice + sizeDelta + boosterTotal + concentrationDelta + pumpExtraCost;
         const quantity = parseInt(document.querySelector('[data-quantity-input]')?.value) || 1;
         const total = subtotal * quantity;
         
@@ -1142,6 +1174,14 @@
         } else {
           sizeUpcharge.style.display = 'none';
         }
+
+        const pumpsUpEl = document.querySelector('[data-pumps-upcharge]');
+        if (pumpExtraCost > 0) {
+          pumpsUpEl.style.display = 'flex';
+          document.querySelector('[data-pumps-price]').textContent = `+$${pumpExtraCost.toFixed(2)}`;
+        } else {
+          pumpsUpEl.style.display = 'none';
+        }
         
         const boostersUpcharge = document.querySelector('[data-boosters-upcharge]');
         if (boosterTotal > 0) {
@@ -1154,6 +1194,20 @@
         // Update totals
         document.querySelector('[data-total-price]').textContent = `$${total.toFixed(2)}`;
         document.querySelector('[data-cart-button-price]').textContent = `$${total.toFixed(2)}`;
+
+        // Write pump-related properties to the hidden inputs
+        if (window.WTFLineItemProperties) {
+          WTFLineItemProperties.update('included-pumps', included);
+          WTFLineItemProperties.update('pump-count', pumpCount);
+          WTFLineItemProperties.update('extra-pumps', extraPumps);
+          WTFLineItemProperties.update('extra-pump-price', priceConfig.extraPumpPrice);
+          WTFLineItemProperties.update('extra-pump-upcharge', pumpExtraCost.toFixed(2));
+          WTFLineItemProperties.update('booster-upcharge', boosterTotal.toFixed(2));
+          WTFLineItemProperties.update('size-upcharge', sizeDelta.toFixed(2));
+        }
+
+        // Refresh the flavor counter with pump info
+        this.updateFlavorCounter();
       },
       
       updateVariantId() {
@@ -1203,6 +1257,13 @@
       updateLineItemProperties() {
         // Update hidden form fields
         if (window.WTFLineItemProperties) {
+          const sizeDelta = this.getSizePriceDelta(this.selectedOptions.size);
+          const included = priceConfig.includedPumps[this.selectedOptions.size] || 0;
+          const pumpCount = this.selectedOptions.flavors.length;
+          const extra = Math.max(0, pumpCount - included);
+          const pumpExtraCost = extra * (priceConfig.extraPumpPrice || 0);
+          const boosterTotal = this.selectedOptions.boosters.reduce((sum, b) => sum + (b.price || 0), 0);
+
           WTFLineItemProperties.update('size', this.capitalizeFirst(this.selectedOptions.size));
           WTFLineItemProperties.update('strain', this.capitalizeFirst(this.selectedOptions.strain));
           WTFLineItemProperties.update('flavor', this.selectedOptions.flavors.map(f => this.capitalizeFirst(f)).join(', '));
@@ -1211,7 +1272,14 @@
           WTFLineItemProperties.update('ice', this.capitalizeFirst(this.selectedOptions.ice));
           WTFLineItemProperties.update('boosters', this.selectedOptions.boosters);
           WTFLineItemProperties.update('instructions', this.selectedOptions.instructions);
-          WTFLineItemProperties.update('size-upcharge', this.getSizePriceDelta(this.selectedOptions.size));
+          WTFLineItemProperties.update('size-upcharge', sizeDelta.toFixed(2));
+
+          WTFLineItemProperties.update('included-pumps', included);
+          WTFLineItemProperties.update('pump-count', pumpCount);
+          WTFLineItemProperties.update('extra-pumps', extra);
+          WTFLineItemProperties.update('extra-pump-price', priceConfig.extraPumpPrice);
+          WTFLineItemProperties.update('extra-pump-upcharge', pumpExtraCost.toFixed(2));
+          WTFLineItemProperties.update('booster-upcharge', boosterTotal.toFixed(2));
         }
       },
       
@@ -1360,7 +1428,18 @@
     {"type":"text","id":"drafts_small_variant","label":"Draft – Small variantId"},
     {"type":"text","id":"drafts_medium_variant","label":"Draft – Medium variantId"},
     {"type":"text","id":"drafts_large_variant","label":"Draft – Large variantId"},
-    {"type":"text","id":"drafts_gallon_variant","label":"Draft – Gallon variantId"}
+    {"type":"text","id":"drafts_gallon_variant","label":"Draft – Gallon variantId"},
+
+    {"type":"header","content":"Pricing & Pumps"},
+    {"type":"number","id":"extra_pump_price","label":"Extra pump price","default":0.5,"step":0.01,"min":0},
+    {"type":"range","id":"included_pumps_small","label":"Included pumps – Small","min":0,"max":12,"step":1,"default":4},
+    {"type":"range","id":"included_pumps_medium","label":"Included pumps – Medium","min":0,"max":12,"step":1,"default":4},
+    {"type":"range","id":"included_pumps_large","label":"Included pumps – Large","min":0,"max":16,"step":1,"default":6},
+    {"type":"range","id":"included_pumps_gallon","label":"Included pumps – Gallon","min":0,"max":64,"step":1,"default":24},
+    {"type":"number","id":"upcharge_small","label":"Size upcharge – Small","default":0,"step":0.01,"min":0},
+    {"type":"number","id":"upcharge_medium","label":"Size upcharge – Medium","default":1,"step":0.01,"min":0},
+    {"type":"number","id":"upcharge_large","label":"Size upcharge – Large","default":2,"step":0.01,"min":0},
+    {"type":"number","id":"upcharge_gallon","label":"Size upcharge – Gallon","default":35,"step":0.01,"min":0}
   ],
   "presets": [
     {

--- a/snippets/wtf-line-item-properties.liquid
+++ b/snippets/wtf-line-item-properties.liquid
@@ -38,6 +38,13 @@
       <!-- Price Adjustments -->
       <input type="hidden" name="properties[_size_upcharge]" value="0" data-property="size-upcharge">
       <input type="hidden" name="properties[_booster_upcharge]" value="0" data-property="booster-upcharge">
+      <input type="hidden" name="properties[_extra_pump_price]" value="0" data-property="extra-pump-price">
+      <input type="hidden" name="properties[_extra_pump_upcharge]" value="0" data-property="extra-pump-upcharge">
+
+      <!-- Pump Accounting -->
+      <input type="hidden" name="properties[Included Pumps]" value="0" data-property="included-pumps">
+      <input type="hidden" name="properties[Pump Count]" value="0" data-property="pump-count">
+      <input type="hidden" name="properties[Extra Pumps]" value="0" data-property="extra-pumps">
       
       <!-- Validation Flag -->
       <input type="hidden" name="properties[_validated]" value="false" data-property="validated">
@@ -64,17 +71,11 @@
         },
         
         handleSizeUpdate: function(size) {
-          // Update size-related properties
-          const sizeUpcharges = {
-            'Small': 0,
-            'Medium': 1,
-            'Large': 2,
-            'Gallon': 35
-          };
-          
+          // Update size-related properties (actual values will be set by section script)
           const upchargeInput = document.querySelector('[data-property="size-upcharge"]');
           if (upchargeInput) {
-            upchargeInput.value = sizeUpcharges[size] || 0;
+            // leave existing value; section JS will overwrite precisely
+            upchargeInput.value = upchargeInput.value || 0;
           }
         },
         

--- a/snippets/wtf-line-item-properties.liquid
+++ b/snippets/wtf-line-item-properties.liquid
@@ -19,6 +19,10 @@
       <!-- Flavor Properties -->
       <input type="hidden" name="properties[Flavor]" value="" data-property="flavor">
       <input type="hidden" name="properties[Flavor Intensity]" value="Regular" data-property="flavor-intensity">
+
+      <!-- Strain / Concentration -->
+      <input type="hidden" name="properties[Strain]" value="" data-property="strain">
+      <input type="hidden" name="properties[Concentration]" value="Regular" data-property="concentration">
       
       <!-- Creamer Properties -->
       <input type="hidden" name="properties[Creamer]" value="" data-property="creamer">


### PR DESCRIPTION
The genspark_ai_developer branch introduces a number of functional improvements focused on pricing flexibility and more granular tracking of drink customization. Key changes include:

Hiding internal properties in the cart – In the cart template, line‑item properties that either start with an underscore, are blank or have the value 'false' are now suppressed. This prevents internal fields (used for validation or pricing) from being displayed to customers
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff#:~:text=,endunless)
.

Configurable pump pricing and size upcharges – The order‑builder section introduces a new priceConfig object that reads its values from section settings. It defines the extra pump price, the included pumps per size (small, medium, large and gallon) and the size upcharge for each size
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff)
. These settings replace the previously hard‑coded size upcharges and open new inputs in the theme editor for merchants to configure pricing
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff#:~:text=%2B%20%20%20%20%7B,0)
.

UI updates to reflect pump counts and charges – The flavor counter now displays how many pumps are selected, how many are included for the chosen size and how many are extra; it also shows the per‑pump price
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff)
. A new price line in the order summary shows the total cost of extra pumps
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff#:~:text=%40%40%20,price%3E%2B%240.00%3C%2Fspan)
, and the logic calculates pump extras by treating each selected flavor as one pump and charging only for pumps beyond the included allotment
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff#:~:text=%2B%20%20%20%20,%28priceConfig.extraPumpPrice%20%7C%7C%200)
.

Dynamic subtotal and line‑item properties – The subtotal calculation now adds pumpExtraCost to the base price, size delta, booster total and concentration delta
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff#:~:text=%2B%20%20%20%20,%28priceConfig.extraPumpPrice%20%7C%7C%200)
. When the order state updates, the script writes pump‑related details (included pumps, pump count, extra pumps, extra pump price and upcharge, booster upcharge and size upcharge) into hidden form fields so they travel with the line item to the cart
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff#:~:text=%2B%20%20%20%20,)
. The same fields are updated in the updateLineItemProperties method to keep the values in sync with the UI
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff#:~:text=%2B%20%2B%20%20%20,upcharge%27%2C%20boosterTotal.toFixed%282%29%29%3B%20%7D)
.

Additional configuration options – The section settings schema now includes a “Pricing & Pumps” header followed by editable fields for extra pump price, included pumps for each size and the size upcharge values
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff#:~:text=%2B%20%20%20%20%7B,0)
. This makes the pump pricing model completely configurable from the theme editor without editing code.

New hidden inputs for Strain, Concentration and pump accounting – The wtf-line-item-properties.liquid snippet adds hidden inputs for storing the selected strain and concentration
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff#:~:text=%3C%21,property%3D%22concentration)
, as well as new fields for extra pump price, extra pump upcharge, included pumps, total pump count and extra pump count
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff#:~:text=%2B%20%20%20%20,pumps)
. The handleSizeUpdate logic has been altered to let the section’s JavaScript fill in the correct upcharge value rather than relying on a static lookup
[github.com](https://github.com/WTFlorida239/wtf-theme-dunkin-style-production/compare/main...genspark_ai_developer.diff#:~:text=)
.

Overall, the enhancements make pump pricing and size surcharges editable through theme settings, adjust the UI to clearly show included and extra pumps and their costs, update the subtotal and hidden line‑item properties accordingly and hide back‑office properties from the cart.

Sources

Agent
3