### PR TITLE
Ensure ordering modal updates cart indicators consistently

### DIFF
--- a/sections/wtf-ordering.liquid
+++ b/sections/wtf-ordering.liquid
@@ -914,12 +914,24 @@ function updatePrice() {
 
 async function updateCartCount() {
   try {
-    const res = await fetch('/cart.js');
-    const data = await res.json();
-    const countEl = document.getElementById('wtf-cart-count');
-    if (countEl) countEl.textContent = data.item_count;
-  } catch (e) {
-    console.error(e);
+    const response = await fetch('/cart.js');
+    if (!response.ok) throw new Error('Cart fetch failed');
+
+    const cart = await response.json();
+    const count = parseInt(cart.item_count || 0, 10);
+
+    document.querySelectorAll('[data-cart-count]').forEach((element) => {
+      element.textContent = count;
+      if (count === 0) {
+        element.setAttribute('hidden', '');
+      } else {
+        element.removeAttribute('hidden');
+      }
+    });
+
+    document.dispatchEvent(new CustomEvent('wtf:cart:update', { detail: { cart } }));
+  } catch (error) {
+    console.error('Failed to update cart count', error);
   }
 }
 


### PR DESCRIPTION
## Summary
- update the ordering modal cart count helper to fetch the latest cart state safely
- hydrate every cart badge marked with data-cart-count and dispatch the shared cart update event

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68ce2192c44c83329e81a9fa16640680