### PR TITLE
fix: reference correct upselling asset

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -261,7 +261,7 @@
     <script src="{{ 'wtf-variants.js' | asset_url }}" defer></script>
     <script src="{{ 'wtf-ajax-cart.js' | asset_url }}" defer></script>
     <script src="{{ 'enhanced-drink-builder.js' | asset_url }}" defer></script>
-    <script src="{{ 'wtf-upselling-system.js' | asset_url }}" defer></script>
+    <script src="{{ 'wtf-upselling.js' | asset_url }}" defer></script>
     <script src="{{ 'wtf-analytics.js' | asset_url }}" defer></script>
 
     {%- comment %} Cart count hydrator (single source of truth) {%- endcomment %}


### PR DESCRIPTION
## Summary
- update the upselling script include in `layout/theme.liquid` to reference the existing `wtf-upselling.js` asset
- ensure no templates still reference the obsolete `wtf-upselling-system.js` filename

## Testing
- Manual Playwright smoke test loading `upsell-test.html` via a local static server to confirm `wtf-upselling.js` returns 200 with no 404 responses

------
https://chatgpt.com/codex/tasks/task_b_68ce1b5eb1f0833298ec1c778f8627f7