### PR TITLE
Remove conflict markers and duplicate drink builder include

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -291,18 +291,5 @@
         });
       })();
     </script>
-<<<<<<< HEAD
-=======
-
-    {# ---------- REMOVE DUPLICATES: no snippet renders or duplicate asset includes below ---------- #}
-    {%- comment -%}
-      Removed duplicates:
-      - {{ 'wtf-ajax-cart.js' | asset_url | script_tag }} (use single deferred asset include above)
-      - {{ 'wtf_flavor_system.js' | asset_url | script_tag }} (load only if needed elsewhere; not required here)
-      - {% render 'wtf-ajax-cart' %} and {% render 'wtf-cart-count' %} (logic centralized in assets + hydrator)
-      - Extra {% render 'wtf-cart-drawer' %} at bottom (drawer already conditionally rendered at top)
-    {%- endcomment -%}
-    {{ 'enhanced-drink-builder.js' | asset_url | script_tag | replace: '<script', '<script defer' }}
->>>>>>> origin/main
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from the main theme layout
- keep a single deferred include for enhanced-drink-builder.js to prevent duplicate loading

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ce1b0b9dd88332b91846169f26ad78